### PR TITLE
Fix exception on missing token

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,7 +40,10 @@ def _autoanswer(sess):
     ans = re.findall(r"A:(\d)<", answeb.json()['content'])[0]
     tokenweb = sess.get(
         'https://ani.gamer.com.tw/ajax/animeGetQuestion.php?t=' + str(int(time.time() * 1000)))
-    token = tokenweb.json()['token']
+    token = tokenweb.json().get('token')
+    if token is None:
+        print('Missing token. Body: {}'.format(tokenweb.json()))
+        return
     data = {
         'token': token,
         'ans': ans,


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/data/data/com.termux/files/home/gamer_autosignin/main.py", line 104, in <module>
    _login(data)
  File "/data/data/com.termux/files/home/gamer_autosignin/main.py", line 94, in _login
    _autoanswer(sess)
  File "/data/data/com.termux/files/home/gamer_autosignin/main.py", line 44, in _autoanswer
    token = tokenweb.json()['token']
KeyError: 'token
```